### PR TITLE
Build on platforms not supporting atomic loads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "typed-path"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41713888c5ccfd99979fcd1afd47b71652e331b3d4a0e19d30769e80fec76cce"
+checksum = "7922f2cdc51280d47b491af9eafc41eb0cdab85eabcb390c854412fcbf26dbe8"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ embedded-io = { version = "0.6.1" }
 log = "0.4.22"
 oem_cp = "2.1.0"
 time = { version = "0.3.36", default-features = false, features = [ "parsing", "macros" ]}
-typed-path = { version = "0.10.0", default-features = false }
+typed-path = { version = "0.12.0", default-features = false }
 
 [features]
 default = ["std", "codepage"]


### PR DESCRIPTION
Resolves #16.

There was an issue with the typed-path dependency, so I opened a PR and kindly asked the maintainer to merge my changes. Once these changes got released to crates.io, all I had to do was bump the dependency version

@alexkazik