### PR TITLE
Use the `wild` linker for CI actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Install the `wild` linker
+        uses: wild-linker/action@latest
       - name: Run tests - All features enabled
         run: |
           cargo build --verbose --all-features


### PR DESCRIPTION
It is a new Rust linker, what's the harm in using it?